### PR TITLE
chore: update example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ After adding this library to your dev/test dependencies and installing, add the 
 
 `test_mypy.py`
 ```test_mypy.py
-from pytest_mypy_runner import test_mypy  # noqa
+from ﻿pytest_mypy_runner.mypy_test_runner import test_mypy  # noqa
 ```
 
 Pytest should then pick up the `test_mypy` test.


### PR DESCRIPTION
The example in the readme resulted in the following type error being reported by pyright:

```
"test_mypy" is not exported from module "pytest_mypy_runner"
Import from "pytest_mypy_runner.mypy_test_runner" instead Pyright (reportPrivateImportUsage) [2, 32]
```

This commit uses the proper import path.